### PR TITLE
bugfix: 'headingRelevance' can't be Char. Changing to String.

### DIFF
--- a/searchanalytics-spark/src/main/scala/canpipe/parser/spark/Parser.scala
+++ b/searchanalytics-spark/src/main/scala/canpipe/parser/spark/Parser.scala
@@ -48,7 +48,7 @@ class eventDetail(
   val tierUdacCountList: String /* /root/Event/search/allListingsTypesMainLists */ ,
   val directoryIdList: String /* /root/Event/search/directoriesReturned */ ,
   val headingId: Long /* /root/Event/search/allHeadings/heading/name */ ,
-  val headingRelevance: Char /* 'A' or 'B'*/ /* /root/Event/search/allHeadings/heading/category */ ,
+  val headingRelevance: String /* 'A' or 'B'*/ /* /root/Event/search/allHeadings/heading/category */ , // TODO: put this as Char. Spark had problems with it - sove them! scala.MatchError: scala.Char (of class scala.reflect.internal.Types$TypeRef$$anon$6)
   val searchType: String /* /root/Event/search/type */ , val searchResultPage: String /* /root/Event/search/resultPage */ ,
   val searchResultPerPage: String /* /root/Event/search/resultPerPage */ , val searchLatitude: String /* /root/Event/search/latitude */ ,
   val searchLongitude: String /* /root/Event/search/longitude */ ,
@@ -297,7 +297,7 @@ object eventDetail {
       case (listOfEvents, (aHeading, itsCategory)) =>
         new eventDetail(
           headingId = runOrDefault[String, Long] { _.toLong }(-1L)(aHeading),
-          headingRelevance = runOrDefault[String, Char] { s => s.charAt(0) }('X')(itsCategory),
+          headingRelevance = itsCategory,
           eventId = getOrEmpty("/root/Event/@id"),
           timestamp = getOrEmpty("/root/Event/@timestamp"),
           timestampId = parseAsLongOrDefault("/root/Event/timestampId", "timestampId"),


### PR DESCRIPTION
Spark is not happy with it:

Exception in thread "main" scala.MatchError: scala.Char (of class scala.reflect.internal.Types$TypeRef$$anon$6)
        at org.apache.spark.sql.catalyst.ScalaReflection$.schemaFor(ScalaReflection.scala:53)
        at org.apache.spark.sql.catalyst.ScalaReflection$$anonfun$schemaFor$1.apply(ScalaReflection.scala:64)
        at org.apache.spark.sql.catalyst.ScalaReflection$$anonfun$schemaFor$1.apply(ScalaReflection.scala:62)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
        at scala.collection.immutable.List.foreach(List.scala:318)
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:244)
        at scala.collection.AbstractTraversable.map(Traversable.scala:105)
        at org.apache.spark.sql.catalyst.ScalaReflection$.schemaFor(ScalaReflection.scala:62)
        at org.apache.spark.sql.catalyst.ScalaReflection$.schemaFor(ScalaReflection.scala:50)
        at org.apache.spark.sql.catalyst.ScalaReflection$.attributesFor(ScalaReflection.scala:44)
        at org.apache.spark.sql.execution.ExistingRdd$.fromProductRdd(basicOperators.scala:229)
        at org.apache.spark.sql.SQLContext.createSchemaRDD(SQLContext.scala:94)
        at canpipe.parser.spark.RunParser$.main(RunParser.scala:153)
        at canpipe.parser.spark.RunParser.main(RunParser.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
        at java.lang.reflect.Method.invoke(Method.java:597)
        at org.apache.spark.deploy.SparkSubmit$.launch(SparkSubmit.scala:331)
        at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:75)
        at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
